### PR TITLE
Adding some customizations

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,10 +32,9 @@ function _footnote_block_close() {
   return '</ol>\n</section>\n';
 }
 function _footnote_open(tokens, idx) {
-  var id = Number(tokens[idx].meta.id + 1).toString(),
-      label = tokens[idx].meta.label;
+  var id = Number(tokens[idx].meta.id + 1).toString();
   if (sub_plugin_options.labels_in_link) {
-    id += ':' + label;
+    id += ':' + tokens[idx].meta.label;
   }
   return '<li id="fn' + id + '"  class="footnote-item">';
 }
@@ -65,7 +64,7 @@ module.exports = function sub_plugin(md, options) {
   if (options) {
     sub_plugin_options = require('merge')(sub_plugin_options, options);
   }
-  
+
   var parseLinkLabel = md.helpers.parseLinkLabel;
 
   md.renderer.rules.footnote_ref          = _footnote_ref;

--- a/index.js
+++ b/index.js
@@ -6,14 +6,22 @@
 // Renderer partials
 
 function _footnote_ref(tokens, idx) {
-  var n = Number(tokens[idx].meta.id + 1).toString();
-  var id = 'fnref' + n;
+  var n = Number(tokens[idx].meta.id + 1).toString(),
+      href = '#fn' + n,
+      id = 'fnref' + n,
+      label = tokens[idx].meta.label,
+      linkText = '[' + n  + ']';
   if (tokens[idx].meta.subId > 0) {
     id += ':' + tokens[idx].meta.subId;
   }
-  var label = tokens[idx].meta.label;
-  id += ':' + label;
-  return '<sup class="footnote-ref"><a href="#fn' + n + ':' + label + '" id="' + id + '">[' + n + ']</a></sup>';
+  if (sub_plugin_options.labels_in_link) {
+    id += ':' + label;
+    href += ':' + label
+  };
+  if (sub_plugin_options.plain_links) {
+    linkText = n;
+  }
+  return '<sup class="footnote-ref"><a href="' + href + '" id="' + id + '">' + linkText + '</a></sup>';
 }
 function _footnote_block_open(tokens, idx, options) {
   return (options.xhtmlOut ? '<hr class="footnotes-sep" />\n' : '<hr class="footnotes-sep">\n') +
@@ -24,29 +32,40 @@ function _footnote_block_close() {
   return '</ol>\n</section>\n';
 }
 function _footnote_open(tokens, idx) {
-  var id = Number(tokens[idx].meta.id + 1).toString();
-  var label = tokens[idx].meta.label;
-  id += ':' + label;
+  var id = Number(tokens[idx].meta.id + 1).toString(),
+      label = tokens[idx].meta.label;
+  if (sub_plugin_options.labels_in_link) {
+    id += ':' + label;
+  }
   return '<li id="fn' + id + '"  class="footnote-item">';
 }
 function _footnote_close() {
   return '</li>\n';
 }
 function _footnote_anchor(tokens, idx) {
-  var n = Number(tokens[idx].meta.id + 1).toString();
-  var id = 'fnref' + n;
+  var n = Number(tokens[idx].meta.id + 1).toString(),
+      id = 'fnref' + n;
   if (tokens[idx].meta.subId > 0) {
     id += ':' + tokens[idx].meta.subId;
   }
-  var label = tokens[idx].meta.label;
-  id += ':' + label;
+  if (sub_plugin_options.labels_in_link) {
+    id += ':' + tokens[idx].meta.label;
+  }
   return ' <a href="#' + id + '" class="footnote-backref">\u21a9</a>'; /* ↩ */
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+var sub_plugin_options = {
+  'plain_links': false,
+  'labels_in_link': false
+};
 
+module.exports = function sub_plugin(md, options) {
 
-module.exports = function sub_plugin(md) {
+  if (options) {
+    sub_plugin_options = require('merge')(sub_plugin_options, options);
+  }
+  
   var parseLinkLabel = md.helpers.parseLinkLabel;
 
   md.renderer.rules.footnote_ref          = _footnote_ref;

--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ function _footnote_ref(tokens, idx) {
   if (tokens[idx].meta.subId > 0) {
     id += ':' + tokens[idx].meta.subId;
   }
-  return '<sup class="footnote-ref"><a href="#fn' + n + '" id="' + id + '">[' + n + ']</a></sup>';
+  var label = tokens[idx].meta.label;
+  id += ':' + label;
+  return '<sup class="footnote-ref"><a href="#fn' + n + ':' + label + '" id="' + id + '">[' + n + ']</a></sup>';
 }
 function _footnote_block_open(tokens, idx, options) {
   return (options.xhtmlOut ? '<hr class="footnotes-sep" />\n' : '<hr class="footnotes-sep">\n') +
@@ -23,6 +25,8 @@ function _footnote_block_close() {
 }
 function _footnote_open(tokens, idx) {
   var id = Number(tokens[idx].meta.id + 1).toString();
+  var label = tokens[idx].meta.label;
+  id += ':' + label;
   return '<li id="fn' + id + '"  class="footnote-item">';
 }
 function _footnote_close() {
@@ -34,6 +38,8 @@ function _footnote_anchor(tokens, idx) {
   if (tokens[idx].meta.subId > 0) {
     id += ':' + tokens[idx].meta.subId;
   }
+  var label = tokens[idx].meta.label;
+  id += ':' + label;
   return ' <a href="#' + id + '" class="footnote-backref">\u21a9</a>'; /* ↩ */
 }
 
@@ -148,6 +154,7 @@ module.exports = function sub_plugin(md) {
       oldLength = state.tokens.length;
       state.md.inline.tokenize(state);
       state.env.footnotes.list[footnoteId] = { tokens: state.tokens.splice(oldLength) };
+      token.meta.label = state.env.footnotes.list[footnoteId];
     }
 
     state.pos = labelEnd + 1;
@@ -202,7 +209,7 @@ module.exports = function sub_plugin(md) {
       state.env.footnotes.list[footnoteId].count++;
 
       token      = state.push('footnote_ref', '', 0);
-      token.meta = { id: footnoteId, subId: footnoteSubId };
+      token.meta = { id: footnoteId, subId: footnoteSubId, label: label};
     }
 
     state.pos = pos;
@@ -243,7 +250,7 @@ module.exports = function sub_plugin(md) {
 
     for (i = 0, l = list.length; i < l; i++) {
       token      = new state.Token('footnote_open', '', 1);
-      token.meta = { id: i };
+      token.meta = { id: i, label: list[i].label };
       state.tokens.push(token);
 
       if (list[i].tokens) {
@@ -276,7 +283,7 @@ module.exports = function sub_plugin(md) {
       t = list[i].count > 0 ? list[i].count : 1;
       for (j = 0; j < t; j++) {
         token      = new state.Token('footnote_anchor', '', 0);
-        token.meta = { id: i, subId: j };
+        token.meta = { id: i, subId: j, label: list[i].label };
         state.tokens.push(token);
       }
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,13 @@
 'use strict';
 
 ////////////////////////////////////////////////////////////////////////////////
+// Plugin default options
+var sub_plugin_options = {
+  'plain_links': false,
+  'labels_in_link': false
+};
+
+////////////////////////////////////////////////////////////////////////////////
 // Renderer partials
 
 function _footnote_ref(tokens, idx) {
@@ -16,8 +23,8 @@ function _footnote_ref(tokens, idx) {
   }
   if (sub_plugin_options.labels_in_link) {
     id += ':' + label;
-    href += ':' + label
-  };
+    href += ':' + label;
+  }
   if (sub_plugin_options.plain_links) {
     linkText = n;
   }
@@ -54,10 +61,6 @@ function _footnote_anchor(tokens, idx) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-var sub_plugin_options = {
-  'plain_links': false,
-  'labels_in_link': false
-};
 
 module.exports = function sub_plugin(md, options) {
 
@@ -227,7 +230,7 @@ module.exports = function sub_plugin(md, options) {
       state.env.footnotes.list[footnoteId].count++;
 
       token      = state.push('footnote_ref', '', 0);
-      token.meta = { id: footnoteId, subId: footnoteSubId, label: label};
+      token.meta = { id: footnoteId, subId: footnoteSubId, label: label };
     }
 
     state.pos = pos;

--- a/index.js
+++ b/index.js
@@ -3,341 +3,340 @@
 'use strict';
 
 module.exports = function(md) {
-////////////////////////////////////////////////////////////////////////////////
-// Plugin default options
-var sub_plugin_options;
+  ////////////////////////////////////////////////////////////////////////////////
+  // Plugin default options
+  var sub_plugin_options;
 
-////////////////////////////////////////////////////////////////////////////////
-// Renderer partials
+  ////////////////////////////////////////////////////////////////////////////////
+  // Renderer partials
 
-function _footnote_ref(tokens, idx) {
-  var n = Number(tokens[idx].meta.id + 1).toString(),
-      href = '#fn' + n,
-      id = 'fnref' + n,
-      label = tokens[idx].meta.label,
-      linkText = '[' + n  + ']',
-      isInlineFootnote;
-  if (tokens[idx].meta.subId > 0) {
-    id += ':' + tokens[idx].meta.subId;
-  }
-  if (sub_plugin_options.labels_in_link) {
-    isInlineFootnote = typeof label !== 'string';
-    if (isInlineFootnote) {
-      label = n;
+  function _footnote_ref(tokens, idx) {
+    var n = Number(tokens[idx].meta.id + 1).toString(),
+        href = '#fn' + n,
+        id = 'fnref' + n,
+        label = tokens[idx].meta.label,
+        linkText = '[' + n  + ']',
+        isInlineFootnote;
+    if (tokens[idx].meta.subId > 0) {
+      id += ':' + tokens[idx].meta.subId;
     }
-    id += ':' + label;
-    href += ':' + label;
-  }
-  if (sub_plugin_options.plain_links) {
-    linkText = n;
-  }
-  return '<sup class="footnote-ref"><a href="' + href + '" id="' + id + '">' + linkText + '</a></sup>';
-}
-function _footnote_block_open(tokens, idx, options) {
-  return (options.xhtmlOut ? '<hr class="footnotes-sep" />\n' : '<hr class="footnotes-sep">\n') +
-         '<section class="footnotes">\n' +
-         '<ol class="footnotes-list">\n';
-}
-function _footnote_block_close() {
-  return '</ol>\n</section>\n';
-}
-function _footnote_open(tokens, idx) {
-  var id = Number(tokens[idx].meta.id + 1).toString(),
-      label = tokens[idx].meta.label,
-      isInlineFootnote;
-  if (sub_plugin_options.labels_in_link) {
-    isInlineFootnote = typeof label !== 'string';
-    if (isInlineFootnote) {
-      label = id;
-    }
-    id += ':' + label;
-  }
-  return '<li id="fn' + id + '"  class="footnote-item">';
-}
-function _footnote_close() {
-  return '</li>\n';
-}
-function _footnote_anchor(tokens, idx) {
-  var n = Number(tokens[idx].meta.id + 1).toString(),
-      id = 'fnref' + n,
-      label = tokens[idx].meta.label,
-      isInlineFootnote;
-  if (tokens[idx].meta.subId > 0) {
-    id += ':' + tokens[idx].meta.subId;
-  }
-  if (sub_plugin_options.labels_in_link) {
-    isInlineFootnote = typeof label !== 'string';
-    if (isInlineFootnote) {
-      label = n;
-    }
-    id += ':' + label;
-  }
-  return ' <a href="#' + id + '" class="footnote-backref">\u21a9</a>'; /* ↩ */
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-function sub_plugin(md, options) {
-
-  var parseLinkLabel = md.helpers.parseLinkLabel;
-
-  md.renderer.rules.footnote_ref          = _footnote_ref;
-  md.renderer.rules.footnote_block_open   = _footnote_block_open;
-  md.renderer.rules.footnote_block_close  = _footnote_block_close;
-  md.renderer.rules.footnote_open         = _footnote_open;
-  md.renderer.rules.footnote_close        = _footnote_close;
-  md.renderer.rules.footnote_anchor       = _footnote_anchor;
-
-  // Process footnote block definition
-  function footnote_def(state, startLine, endLine, silent) {
-    var oldBMark, oldTShift, oldParentType, pos, label, token,
-        start = state.bMarks[startLine] + state.tShift[startLine],
-        max = state.eMarks[startLine];
-
-    // line should be at least 5 chars - "[^x]:"
-    if (start + 4 > max) { return false; }
-
-    if (state.src.charCodeAt(start) !== 0x5B/* [ */) { return false; }
-    if (state.src.charCodeAt(start + 1) !== 0x5E/* ^ */) { return false; }
-
-    for (pos = start + 2; pos < max; pos++) {
-      if (state.src.charCodeAt(pos) === 0x20) { return false; }
-      if (state.src.charCodeAt(pos) === 0x5D /* ] */) {
-        break;
+    if (sub_plugin_options.labels_in_link) {
+      isInlineFootnote = typeof label !== 'string';
+      if (isInlineFootnote) {
+        label = n;
       }
+      id += ':' + label;
+      href += ':' + label;
     }
-
-    if (pos === start + 2) { return false; } // no empty footnote labels
-    if (pos + 1 >= max || state.src.charCodeAt(++pos) !== 0x3A /* : */) { return false; }
-    if (silent) { return true; }
-    pos++;
-
-    if (!state.env.footnotes) { state.env.footnotes = {}; }
-    if (!state.env.footnotes.refs) { state.env.footnotes.refs = {}; }
-    label = state.src.slice(start + 2, pos - 2);
-    state.env.footnotes.refs[':' + label] = -1;
-
-    token       = new state.Token('footnote_reference_open', '', 1);
-    token.meta  = { label: label };
-    token.level = state.level++;
-    state.tokens.push(token);
-
-    oldBMark = state.bMarks[startLine];
-    oldTShift = state.tShift[startLine];
-    oldParentType = state.parentType;
-    state.tShift[startLine] = state.skipSpaces(pos) - pos;
-    state.bMarks[startLine] = pos;
-    state.blkIndent += 4;
-    state.parentType = 'footnote';
-
-    if (state.tShift[startLine] < state.blkIndent) {
-      state.tShift[startLine] += state.blkIndent;
-      state.bMarks[startLine] -= state.blkIndent;
+    if (sub_plugin_options.plain_links) {
+      linkText = n;
     }
-
-    state.md.block.tokenize(state, startLine, endLine, true);
-
-    state.parentType = oldParentType;
-    state.blkIndent -= 4;
-    state.tShift[startLine] = oldTShift;
-    state.bMarks[startLine] = oldBMark;
-
-    token       = new state.Token('footnote_reference_close', '', -1);
-    token.level = --state.level;
-    state.tokens.push(token);
-
-    return true;
+    return '<sup class="footnote-ref"><a href="' + href + '" id="' + id + '">' + linkText + '</a></sup>';
+  }
+  function _footnote_block_open(tokens, idx, options) {
+    return (options.xhtmlOut ? '<hr class="footnotes-sep" />\n' : '<hr class="footnotes-sep">\n') +
+           '<section class="footnotes">\n' +
+           '<ol class="footnotes-list">\n';
+  }
+  function _footnote_block_close() {
+    return '</ol>\n</section>\n';
+  }
+  function _footnote_open(tokens, idx) {
+    var id = Number(tokens[idx].meta.id + 1).toString(),
+        label = tokens[idx].meta.label,
+        isInlineFootnote;
+    if (sub_plugin_options.labels_in_link) {
+      isInlineFootnote = typeof label !== 'string';
+      if (isInlineFootnote) {
+        label = id;
+      }
+      id += ':' + label;
+    }
+    return '<li id="fn' + id + '"  class="footnote-item">';
+  }
+  function _footnote_close() {
+    return '</li>\n';
+  }
+  function _footnote_anchor(tokens, idx) {
+    var n = Number(tokens[idx].meta.id + 1).toString(),
+        id = 'fnref' + n,
+        label = tokens[idx].meta.label,
+        isInlineFootnote;
+    if (tokens[idx].meta.subId > 0) {
+      id += ':' + tokens[idx].meta.subId;
+    }
+    if (sub_plugin_options.labels_in_link) {
+      isInlineFootnote = typeof label !== 'string';
+      if (isInlineFootnote) {
+        label = n;
+      }
+      id += ':' + label;
+    }
+    return ' <a href="#' + id + '" class="footnote-backref">\u21a9</a>'; /* ↩ */
   }
 
-  // Process inline footnotes (^[...])
-  function footnote_inline(state, silent) {
-    var labelStart,
-        labelEnd,
-        footnoteId,
-        oldLength,
-        token,
-        max = state.posMax,
-        start = state.pos;
+  ////////////////////////////////////////////////////////////////////////////////
 
-    if (start + 2 >= max) { return false; }
-    if (state.src.charCodeAt(start) !== 0x5E/* ^ */) { return false; }
-    if (state.src.charCodeAt(start + 1) !== 0x5B/* [ */) { return false; }
+  function sub_plugin(md) {
 
-    labelStart = start + 2;
-    labelEnd = parseLinkLabel(state, start + 1);
+    var parseLinkLabel = md.helpers.parseLinkLabel;
 
-    // parser failed to find ']', so it's not a valid note
-    if (labelEnd < 0) { return false; }
+    md.renderer.rules.footnote_ref          = _footnote_ref;
+    md.renderer.rules.footnote_block_open   = _footnote_block_open;
+    md.renderer.rules.footnote_block_close  = _footnote_block_close;
+    md.renderer.rules.footnote_open         = _footnote_open;
+    md.renderer.rules.footnote_close        = _footnote_close;
+    md.renderer.rules.footnote_anchor       = _footnote_anchor;
 
-    // We found the end of the link, and know for a fact it's a valid link;
-    // so all that's left to do is to call tokenizer.
-    //
-    if (!silent) {
+    // Process footnote block definition
+    function footnote_def(state, startLine, endLine, silent) {
+      var oldBMark, oldTShift, oldParentType, pos, label, token,
+          start = state.bMarks[startLine] + state.tShift[startLine],
+          max = state.eMarks[startLine];
+
+      // line should be at least 5 chars - "[^x]:"
+      if (start + 4 > max) { return false; }
+
+      if (state.src.charCodeAt(start) !== 0x5B/* [ */) { return false; }
+      if (state.src.charCodeAt(start + 1) !== 0x5E/* ^ */) { return false; }
+
+      for (pos = start + 2; pos < max; pos++) {
+        if (state.src.charCodeAt(pos) === 0x20) { return false; }
+        if (state.src.charCodeAt(pos) === 0x5D /* ] */) {
+          break;
+        }
+      }
+
+      if (pos === start + 2) { return false; } // no empty footnote labels
+      if (pos + 1 >= max || state.src.charCodeAt(++pos) !== 0x3A /* : */) { return false; }
+      if (silent) { return true; }
+      pos++;
+
       if (!state.env.footnotes) { state.env.footnotes = {}; }
-      if (!state.env.footnotes.list) { state.env.footnotes.list = []; }
-      footnoteId = state.env.footnotes.list.length;
+      if (!state.env.footnotes.refs) { state.env.footnotes.refs = {}; }
+      label = state.src.slice(start + 2, pos - 2);
+      state.env.footnotes.refs[':' + label] = -1;
 
-      state.pos = labelStart;
-      state.posMax = labelEnd;
-
-      token      = state.push('footnote_ref', '', 0);
-      token.meta = { id: footnoteId };
-
-      oldLength = state.tokens.length;
-      state.md.inline.tokenize(state);
-      state.env.footnotes.list[footnoteId] = { tokens: state.tokens.splice(oldLength) };
-      token.meta.label = state.env.footnotes.list[footnoteId].tokens;
-    }
-
-    state.pos = labelEnd + 1;
-    state.posMax = max;
-    return true;
-  }
-
-  // Process footnote references ([^...])
-  function footnote_ref(state, silent) {
-    var label,
-        pos,
-        footnoteId,
-        footnoteSubId,
-        token,
-        max = state.posMax,
-        start = state.pos;
-
-    // should be at least 4 chars - "[^x]"
-    if (start + 3 > max) { return false; }
-
-    if (!state.env.footnotes || !state.env.footnotes.refs) { return false; }
-    if (state.src.charCodeAt(start) !== 0x5B/* [ */) { return false; }
-    if (state.src.charCodeAt(start + 1) !== 0x5E/* ^ */) { return false; }
-
-    for (pos = start + 2; pos < max; pos++) {
-      if (state.src.charCodeAt(pos) === 0x20) { return false; }
-      if (state.src.charCodeAt(pos) === 0x0A) { return false; }
-      if (state.src.charCodeAt(pos) === 0x5D /* ] */) {
-        break;
-      }
-    }
-
-    if (pos === start + 2) { return false; } // no empty footnote labels
-    if (pos >= max) { return false; }
-    pos++;
-
-    label = state.src.slice(start + 2, pos - 1);
-    if (typeof state.env.footnotes.refs[':' + label] === 'undefined') { return false; }
-
-    if (!silent) {
-      if (!state.env.footnotes.list) { state.env.footnotes.list = []; }
-
-      if (state.env.footnotes.refs[':' + label] < 0) {
-        footnoteId = state.env.footnotes.list.length;
-        state.env.footnotes.list[footnoteId] = { label: label, count: 0 };
-        state.env.footnotes.refs[':' + label] = footnoteId;
-      } else {
-        footnoteId = state.env.footnotes.refs[':' + label];
-      }
-
-      footnoteSubId = state.env.footnotes.list[footnoteId].count;
-      state.env.footnotes.list[footnoteId].count++;
-
-      token      = state.push('footnote_ref', '', 0);
-      token.meta = { id: footnoteId, subId: footnoteSubId, label: label };
-    }
-
-    state.pos = pos;
-    state.posMax = max;
-    return true;
-  }
-
-  // Glue footnote tokens to end of token stream
-  function footnote_tail(state) {
-    var i, l, j, t, lastParagraph, list, token, tokens, current, currentLabel,
-        insideRef = false,
-        refTokens = {};
-
-    if (!state.env.footnotes) { return; }
-
-    state.tokens = state.tokens.filter(function(tok) {
-      if (tok.type === 'footnote_reference_open') {
-        insideRef = true;
-        current = [];
-        currentLabel = tok.meta.label;
-        return false;
-      }
-      if (tok.type === 'footnote_reference_close') {
-        insideRef = false;
-        // prepend ':' to avoid conflict with Object.prototype members
-        refTokens[':' + currentLabel] = current;
-        return false;
-      }
-      if (insideRef) { current.push(tok); }
-      return !insideRef;
-    });
-
-    if (!state.env.footnotes.list) { return; }
-    list = state.env.footnotes.list;
-
-    token = new state.Token('footnote_block_open', '', 1);
-    state.tokens.push(token);
-
-    for (i = 0, l = list.length; i < l; i++) {
-      token      = new state.Token('footnote_open', '', 1);
-      token.meta = { id: i, label: list[i].label };
+      token       = new state.Token('footnote_reference_open', '', 1);
+      token.meta  = { label: label };
+      token.level = state.level++;
       state.tokens.push(token);
 
-      if (list[i].tokens) {
-        tokens = [];
+      oldBMark = state.bMarks[startLine];
+      oldTShift = state.tShift[startLine];
+      oldParentType = state.parentType;
+      state.tShift[startLine] = state.skipSpaces(pos) - pos;
+      state.bMarks[startLine] = pos;
+      state.blkIndent += 4;
+      state.parentType = 'footnote';
 
-        token          = new state.Token('paragraph_open', 'p', 1);
-        token.block    = true;
-        tokens.push(token);
-
-        token          = new state.Token('inline', '', 0);
-        token.children = list[i].tokens;
-        token.content  = '';
-        tokens.push(token);
-
-        token          = new state.Token('paragraph_close', 'p', -1);
-        token.block    = true;
-        tokens.push(token);
-
-      } else if (list[i].label) {
-        tokens = refTokens[':' + list[i].label];
+      if (state.tShift[startLine] < state.blkIndent) {
+        state.tShift[startLine] += state.blkIndent;
+        state.bMarks[startLine] -= state.blkIndent;
       }
 
-      state.tokens = state.tokens.concat(tokens);
-      if (state.tokens[state.tokens.length - 1].type === 'paragraph_close') {
-        lastParagraph = state.tokens.pop();
-      } else {
-        lastParagraph = null;
+      state.md.block.tokenize(state, startLine, endLine, true);
+
+      state.parentType = oldParentType;
+      state.blkIndent -= 4;
+      state.tShift[startLine] = oldTShift;
+      state.bMarks[startLine] = oldBMark;
+
+      token       = new state.Token('footnote_reference_close', '', -1);
+      token.level = --state.level;
+      state.tokens.push(token);
+
+      return true;
+    }
+
+    // Process inline footnotes (^[...])
+    function footnote_inline(state, silent) {
+      var labelStart,
+          labelEnd,
+          footnoteId,
+          oldLength,
+          token,
+          max = state.posMax,
+          start = state.pos;
+
+      if (start + 2 >= max) { return false; }
+      if (state.src.charCodeAt(start) !== 0x5E/* ^ */) { return false; }
+      if (state.src.charCodeAt(start + 1) !== 0x5B/* [ */) { return false; }
+
+      labelStart = start + 2;
+      labelEnd = parseLinkLabel(state, start + 1);
+
+      // parser failed to find ']', so it's not a valid note
+      if (labelEnd < 0) { return false; }
+
+      // We found the end of the link, and know for a fact it's a valid link;
+      // so all that's left to do is to call tokenizer.
+      //
+      if (!silent) {
+        if (!state.env.footnotes) { state.env.footnotes = {}; }
+        if (!state.env.footnotes.list) { state.env.footnotes.list = []; }
+        footnoteId = state.env.footnotes.list.length;
+
+        state.pos = labelStart;
+        state.posMax = labelEnd;
+
+        token      = state.push('footnote_ref', '', 0);
+        token.meta = { id: footnoteId };
+
+        oldLength = state.tokens.length;
+        state.md.inline.tokenize(state);
+        state.env.footnotes.list[footnoteId] = { tokens: state.tokens.splice(oldLength) };
+        token.meta.label = state.env.footnotes.list[footnoteId].tokens;
       }
 
-      t = list[i].count > 0 ? list[i].count : 1;
-      for (j = 0; j < t; j++) {
-        token      = new state.Token('footnote_anchor', '', 0);
-        token.meta = { id: i, subId: j, label: list[i].label };
+      state.pos = labelEnd + 1;
+      state.posMax = max;
+      return true;
+    }
+
+    // Process footnote references ([^...])
+    function footnote_ref(state, silent) {
+      var label,
+          pos,
+          footnoteId,
+          footnoteSubId,
+          token,
+          max = state.posMax,
+          start = state.pos;
+
+      // should be at least 4 chars - "[^x]"
+      if (start + 3 > max) { return false; }
+
+      if (!state.env.footnotes || !state.env.footnotes.refs) { return false; }
+      if (state.src.charCodeAt(start) !== 0x5B/* [ */) { return false; }
+      if (state.src.charCodeAt(start + 1) !== 0x5E/* ^ */) { return false; }
+
+      for (pos = start + 2; pos < max; pos++) {
+        if (state.src.charCodeAt(pos) === 0x20) { return false; }
+        if (state.src.charCodeAt(pos) === 0x0A) { return false; }
+        if (state.src.charCodeAt(pos) === 0x5D /* ] */) {
+          break;
+        }
+      }
+
+      if (pos === start + 2) { return false; } // no empty footnote labels
+      if (pos >= max) { return false; }
+      pos++;
+
+      label = state.src.slice(start + 2, pos - 1);
+      if (typeof state.env.footnotes.refs[':' + label] === 'undefined') { return false; }
+
+      if (!silent) {
+        if (!state.env.footnotes.list) { state.env.footnotes.list = []; }
+
+        if (state.env.footnotes.refs[':' + label] < 0) {
+          footnoteId = state.env.footnotes.list.length;
+          state.env.footnotes.list[footnoteId] = { label: label, count: 0 };
+          state.env.footnotes.refs[':' + label] = footnoteId;
+        } else {
+          footnoteId = state.env.footnotes.refs[':' + label];
+        }
+
+        footnoteSubId = state.env.footnotes.list[footnoteId].count;
+        state.env.footnotes.list[footnoteId].count++;
+
+        token      = state.push('footnote_ref', '', 0);
+        token.meta = { id: footnoteId, subId: footnoteSubId, label: label };
+      }
+
+      state.pos = pos;
+      state.posMax = max;
+      return true;
+    }
+
+    // Glue footnote tokens to end of token stream
+    function footnote_tail(state) {
+      var i, l, j, t, lastParagraph, list, token, tokens, current, currentLabel,
+          insideRef = false,
+          refTokens = {};
+
+      if (!state.env.footnotes) { return; }
+
+      state.tokens = state.tokens.filter(function(tok) {
+        if (tok.type === 'footnote_reference_open') {
+          insideRef = true;
+          current = [];
+          currentLabel = tok.meta.label;
+          return false;
+        }
+        if (tok.type === 'footnote_reference_close') {
+          insideRef = false;
+          // prepend ':' to avoid conflict with Object.prototype members
+          refTokens[':' + currentLabel] = current;
+          return false;
+        }
+        if (insideRef) { current.push(tok); }
+        return !insideRef;
+      });
+
+      if (!state.env.footnotes.list) { return; }
+      list = state.env.footnotes.list;
+
+      token = new state.Token('footnote_block_open', '', 1);
+      state.tokens.push(token);
+
+      for (i = 0, l = list.length; i < l; i++) {
+        token      = new state.Token('footnote_open', '', 1);
+        token.meta = { id: i, label: list[i].label };
+        state.tokens.push(token);
+
+        if (list[i].tokens) {
+          tokens = [];
+
+          token          = new state.Token('paragraph_open', 'p', 1);
+          token.block    = true;
+          tokens.push(token);
+
+          token          = new state.Token('inline', '', 0);
+          token.children = list[i].tokens;
+          token.content  = '';
+          tokens.push(token);
+
+          token          = new state.Token('paragraph_close', 'p', -1);
+          token.block    = true;
+          tokens.push(token);
+
+        } else if (list[i].label) {
+          tokens = refTokens[':' + list[i].label];
+        }
+
+        state.tokens = state.tokens.concat(tokens);
+        if (state.tokens[state.tokens.length - 1].type === 'paragraph_close') {
+          lastParagraph = state.tokens.pop();
+        } else {
+          lastParagraph = null;
+        }
+
+        t = list[i].count > 0 ? list[i].count : 1;
+        for (j = 0; j < t; j++) {
+          token      = new state.Token('footnote_anchor', '', 0);
+          token.meta = { id: i, subId: j, label: list[i].label };
+          state.tokens.push(token);
+        }
+
+        if (lastParagraph) {
+          state.tokens.push(lastParagraph);
+        }
+
+        token = new state.Token('footnote_close', '', -1);
         state.tokens.push(token);
       }
 
-      if (lastParagraph) {
-        state.tokens.push(lastParagraph);
-      }
-
-      token = new state.Token('footnote_close', '', -1);
+      token = new state.Token('footnote_block_close', '', -1);
       state.tokens.push(token);
     }
 
-    token = new state.Token('footnote_block_close', '', -1);
-    state.tokens.push(token);
+    md.block.ruler.before('reference', 'footnote_def', footnote_def, { alt: [ 'paragraph', 'reference' ] });
+    md.inline.ruler.after('image', 'footnote_inline', footnote_inline);
+    md.inline.ruler.after('footnote_inline', 'footnote_ref', footnote_ref);
+    md.core.ruler.after('inline', 'footnote_tail', footnote_tail);
   }
 
-  md.block.ruler.before('reference', 'footnote_def', footnote_def, { alt: [ 'paragraph', 'reference' ] });
-  md.inline.ruler.after('image', 'footnote_inline', footnote_inline);
-  md.inline.ruler.after('footnote_inline', 'footnote_ref', footnote_ref);
-  md.core.ruler.after('inline', 'footnote_tail', footnote_tail);
-};
-
-  
   var isOldCall = md instanceof require('markdown-it');
   sub_plugin_options = {
     'plain_links': false,
@@ -350,4 +349,4 @@ function sub_plugin(md, options) {
     sub_plugin_options = require('merge')(sub_plugin_options, md);
   }
   return sub_plugin;
-}
+};

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "markdown-it-testgen": "~0.1.0",
     "mocha": "*",
     "request": "*",
-    "uglify-js": "*",
+    "uglify-js": "*"
+  },
+  "dependencies" : {
     "merge": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "markdown-it-testgen": "~0.1.0",
     "mocha": "*",
     "request": "*",
-    "uglify-js": "*"
+    "uglify-js": "*",
+    "merge": "^1.2.0"
   }
 }

--- a/test/fixtures/footnote_labels.txt
+++ b/test/fixtures/footnote_labels.txt
@@ -1,0 +1,436 @@
+
+Pandoc example:
+.
+Here is a footnote reference,[^1] and another.[^longnote]
+
+[^1]: Here is the footnote.
+
+[^longnote]: Here's one with multiple blocks.
+
+    Subsequent paragraphs are indented to show that they
+belong to the previous footnote.
+
+        { some.code }
+
+    The whole paragraph can be indented, or just the first
+    line.  In this way, multi-paragraph footnotes work like
+    multi-paragraph list items.
+
+This paragraph won't be part of the note, because it
+isn't indented.
+.
+<p>Here is a footnote reference,<sup class="footnote-ref"><a href="#fn1:1" id="fnref1:1">[1]</a></sup> and another.<sup class="footnote-ref"><a href="#fn2:longnote" id="fnref2:longnote">[2]</a></sup></p>
+<p>This paragraph won't be part of the note, because it
+isn't indented.</p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:1"  class="footnote-item"><p>Here is the footnote. <a href="#fnref1:1" class="footnote-backref">↩</a></p>
+</li>
+<li id="fn2:longnote"  class="footnote-item"><p>Here's one with multiple blocks.</p>
+<p>Subsequent paragraphs are indented to show that they
+belong to the previous footnote.</p>
+<pre><code>{ some.code }
+</code></pre>
+<p>The whole paragraph can be indented, or just the first
+line.  In this way, multi-paragraph footnotes work like
+multi-paragraph list items. <a href="#fnref2:longnote" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+
+They could terminate each other:
+
+.
+[^1][^2][^3]
+
+[^1]: foo
+[^2]: bar
+[^3]: baz
+.
+<p><sup class="footnote-ref"><a href="#fn1:1" id="fnref1:1">[1]</a></sup><sup class="footnote-ref"><a href="#fn2:2" id="fnref2:2">[2]</a></sup><sup class="footnote-ref"><a href="#fn3:3" id="fnref3:3">[3]</a></sup></p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:1"  class="footnote-item"><p>foo <a href="#fnref1:1" class="footnote-backref">↩</a></p>
+</li>
+<li id="fn2:2"  class="footnote-item"><p>bar <a href="#fnref2:2" class="footnote-backref">↩</a></p>
+</li>
+<li id="fn3:3"  class="footnote-item"><p>baz <a href="#fnref3:3" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+They could be inside blockquotes, and are lazy:
+.
+[^foo]
+
+> [^foo]: bar
+baz
+.
+<p><sup class="footnote-ref"><a href="#fn1:foo" id="fnref1:foo">[1]</a></sup></p>
+<blockquote></blockquote>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:foo"  class="footnote-item"><p>bar
+baz <a href="#fnref1:foo" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+Their labels could not contain spaces or newlines:
+
+.
+[^ foo]: bar baz
+
+[^foo
+]: bar baz
+.
+<p>[^ foo]: bar baz</p>
+<p>[^foo
+]: bar baz</p>
+.
+
+
+We support inline notes too (pandoc example):
+
+.
+Here is an inline note.^[Inlines notes are easier to write, since
+you don't have to pick an identifier and move down to type the
+note.]
+.
+<p>Here is an inline note.<sup class="footnote-ref"><a href="#fn1:1" id="fnref1:1">[1]</a></sup></p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:1"  class="footnote-item"><p>Inlines notes are easier to write, since
+you don't have to pick an identifier and move down to type the
+note. <a href="#fnref1:1" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+They could have arbitrary markup:
+
+.
+foo^[ *bar* ]
+.
+<p>foo<sup class="footnote-ref"><a href="#fn1:1" id="fnref1:1">[1]</a></sup></p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:1"  class="footnote-item"><p> <em>bar</em>  <a href="#fnref1:1" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+Indents:
+
+.
+[^xxxxx] [^yyyyy]
+
+[^xxxxx]: foo
+    ---
+
+[^yyyyy]: foo
+   ---
+.
+<p><sup class="footnote-ref"><a href="#fn1:xxxxx" id="fnref1:xxxxx">[1]</a></sup> <sup class="footnote-ref"><a href="#fn2:yyyyy" id="fnref2:yyyyy">[2]</a></sup></p>
+<hr>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:xxxxx"  class="footnote-item"><h2>foo</h2>
+ <a href="#fnref1:xxxxx" class="footnote-backref">↩</a></li>
+<li id="fn2:yyyyy"  class="footnote-item"><p>foo <a href="#fnref2:yyyyy" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+Indents for the first line:
+
+.
+[^xxxxx] [^yyyyy]
+
+[^xxxxx]:       foo
+
+[^yyyyy]:        foo
+.
+<p><sup class="footnote-ref"><a href="#fn1:xxxxx" id="fnref1:xxxxx">[1]</a></sup> <sup class="footnote-ref"><a href="#fn2:yyyyy" id="fnref2:yyyyy">[2]</a></sup></p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:xxxxx"  class="footnote-item"><p>foo <a href="#fnref1:xxxxx" class="footnote-backref">↩</a></p>
+</li>
+<li id="fn2:yyyyy"  class="footnote-item"><pre><code>foo
+</code></pre>
+ <a href="#fnref2:yyyyy" class="footnote-backref">↩</a></li>
+</ol>
+</section>
+.
+
+
+Security 1
+.
+[^__proto__]
+
+[^__proto__]: blah
+.
+<p><sup class="footnote-ref"><a href="#fn1:__proto__" id="fnref1:__proto__">[1]</a></sup></p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:__proto__"  class="footnote-item"><p>blah <a href="#fnref1:__proto__" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+Security 2
+.
+[^hasOwnProperty]
+
+[^hasOwnProperty]: blah
+.
+<p><sup class="footnote-ref"><a href="#fn1:hasOwnProperty" id="fnref1:hasOwnProperty">[1]</a></sup></p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:hasOwnProperty"  class="footnote-item"><p>blah <a href="#fnref1:hasOwnProperty" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+Pandoc example:
+.
+Here is a footnote reference,[^1] and another.[^longnote]
+
+[^1]: Here is the footnote.
+
+[^longnote]: Here's one with multiple blocks.
+
+    Subsequent paragraphs are indented to show that they
+belong to the previous footnote.
+
+        { some.code }
+
+    The whole paragraph can be indented, or just the first
+    line.  In this way, multi-paragraph footnotes work like
+    multi-paragraph list items.
+
+This paragraph won't be part of the note, because it
+isn't indented.
+.
+<p>Here is a footnote reference,<sup class="footnote-ref"><a href="#fn1:1" id="fnref1:1">[1]</a></sup> and another.<sup class="footnote-ref"><a href="#fn2:longnote" id="fnref2:longnote">[2]</a></sup></p>
+<p>This paragraph won't be part of the note, because it
+isn't indented.</p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:1"  class="footnote-item"><p>Here is the footnote. <a href="#fnref1:1" class="footnote-backref">↩</a></p>
+</li>
+<li id="fn2:longnote"  class="footnote-item"><p>Here's one with multiple blocks.</p>
+<p>Subsequent paragraphs are indented to show that they
+belong to the previous footnote.</p>
+<pre><code>{ some.code }
+</code></pre>
+<p>The whole paragraph can be indented, or just the first
+line.  In this way, multi-paragraph footnotes work like
+multi-paragraph list items. <a href="#fnref2:longnote" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+
+They could terminate each other:
+
+.
+[^1][^2][^3]
+
+[^1]: foo
+[^2]: bar
+[^3]: baz
+.
+<p><sup class="footnote-ref"><a href="#fn1:1" id="fnref1:1">[1]</a></sup><sup class="footnote-ref"><a href="#fn2:2" id="fnref2:2">[2]</a></sup><sup class="footnote-ref"><a href="#fn3:3" id="fnref3:3">[3]</a></sup></p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:1"  class="footnote-item"><p>foo <a href="#fnref1:1" class="footnote-backref">↩</a></p>
+</li>
+<li id="fn2:2"  class="footnote-item"><p>bar <a href="#fnref2:2" class="footnote-backref">↩</a></p>
+</li>
+<li id="fn3:3"  class="footnote-item"><p>baz <a href="#fnref3:3" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+They could be inside blockquotes, and are lazy:
+.
+[^foo]
+
+> [^foo]: bar
+baz
+.
+<p><sup class="footnote-ref"><a href="#fn1:foo" id="fnref1:foo">[1]</a></sup></p>
+<blockquote></blockquote>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:foo"  class="footnote-item"><p>bar
+baz <a href="#fnref1:foo" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+Their labels could not contain spaces or newlines:
+
+.
+[^ foo]: bar baz
+
+[^foo
+]: bar baz
+.
+<p>[^ foo]: bar baz</p>
+<p>[^foo
+]: bar baz</p>
+.
+
+
+We support inline notes too (pandoc example):
+
+.
+Here is an inline note.^[Inlines notes are easier to write, since
+you don't have to pick an identifier and move down to type the
+note.]
+.
+<p>Here is an inline note.<sup class="footnote-ref"><a href="#fn1:1" id="fnref1:1">[1]</a></sup></p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:1"  class="footnote-item"><p>Inlines notes are easier to write, since
+you don't have to pick an identifier and move down to type the
+note. <a href="#fnref1:1" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+They could have arbitrary markup:
+
+.
+foo^[ *bar* ]
+.
+<p>foo<sup class="footnote-ref"><a href="#fn1:1" id="fnref1:1">[1]</a></sup></p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:1"  class="footnote-item"><p> <em>bar</em>  <a href="#fnref1:1" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+Indents:
+
+.
+[^xxxxx] [^yyyyy]
+
+[^xxxxx]: foo
+    ---
+
+[^yyyyy]: foo
+   ---
+.
+<p><sup class="footnote-ref"><a href="#fn1:xxxxx" id="fnref1:xxxxx">[1]</a></sup> <sup class="footnote-ref"><a href="#fn2:yyyyy" id="fnref2:yyyyy">[2]</a></sup></p>
+<hr>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:xxxxx"  class="footnote-item"><h2>foo</h2>
+ <a href="#fnref1:xxxxx" class="footnote-backref">↩</a></li>
+<li id="fn2:yyyyy"  class="footnote-item"><p>foo <a href="#fnref2:yyyyy" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+Indents for the first line:
+
+.
+[^xxxxx] [^yyyyy]
+
+[^xxxxx]:       foo
+
+[^yyyyy]:        foo
+.
+<p><sup class="footnote-ref"><a href="#fn1:xxxxx" id="fnref1:xxxxx">[1]</a></sup> <sup class="footnote-ref"><a href="#fn2:yyyyy" id="fnref2:yyyyy">[2]</a></sup></p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:xxxxx"  class="footnote-item"><p>foo <a href="#fnref1:xxxxx" class="footnote-backref">↩</a></p>
+</li>
+<li id="fn2:yyyyy"  class="footnote-item"><pre><code>foo
+</code></pre>
+ <a href="#fnref2:yyyyy" class="footnote-backref">↩</a></li>
+</ol>
+</section>
+.
+
+
+Security 1
+.
+[^__proto__]
+
+[^__proto__]: blah
+.
+<p><sup class="footnote-ref"><a href="#fn1:__proto__" id="fnref1:__proto__">[1]</a></sup></p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:__proto__"  class="footnote-item"><p>blah <a href="#fnref1:__proto__" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.
+
+
+Security 2
+.
+[^hasOwnProperty]
+
+[^hasOwnProperty]: blah
+.
+<p><sup class="footnote-ref"><a href="#fn1:hasOwnProperty" id="fnref1:hasOwnProperty">[1]</a></sup></p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1:hasOwnProperty"  class="footnote-item"><p>blah <a href="#fnref1:hasOwnProperty" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.

--- a/test/fixtures/footnote_simple_link.txt
+++ b/test/fixtures/footnote_simple_link.txt
@@ -1,0 +1,41 @@
+
+Pandoc example:
+.
+Here is a footnote reference,[^1] and another.[^longnote]
+
+[^1]: Here is the footnote.
+
+[^longnote]: Here's one with multiple blocks.
+
+    Subsequent paragraphs are indented to show that they
+belong to the previous footnote.
+
+        { some.code }
+
+    The whole paragraph can be indented, or just the first
+    line.  In this way, multi-paragraph footnotes work like
+    multi-paragraph list items.
+
+This paragraph won't be part of the note, because it
+isn't indented.
+.
+<p>Here is a footnote reference,<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup> and another.<sup class="footnote-ref"><a href="#fn2" id="fnref2">2</a></sup></p>
+<p>This paragraph won't be part of the note, because it
+isn't indented.</p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn1"  class="footnote-item"><p>Here is the footnote. <a href="#fnref1" class="footnote-backref">↩</a></p>
+</li>
+<li id="fn2"  class="footnote-item"><p>Here's one with multiple blocks.</p>
+<p>Subsequent paragraphs are indented to show that they
+belong to the previous footnote.</p>
+<pre><code>{ some.code }
+</code></pre>
+<p>The whole paragraph can be indented, or just the first
+line.  In this way, multi-paragraph footnotes work like
+multi-paragraph list items. <a href="#fnref2" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.

--- a/test/test.js
+++ b/test/test.js
@@ -15,22 +15,20 @@ describe('markdown-it-footnote', function () {
 
 describe('markdown-it-footnote-labels', function () {
   var md = require('markdown-it')()
-              .use(require('../')( 
-                {
-                    'labels_in_link': true
-                })
-              );
+              .use(require('../')({
+                'labels_in_link': true
+              })
+            );
 
   generate(path.join(__dirname, 'fixtures/footnote_labels.txt'), md);
 });
 
 describe('markdown-it-footnote-simple-links', function () {
   var md = require('markdown-it')()
-              .use(require('../')( 
-                {
-                    'plain_links': true
-                })
-              );
+              .use(require('../')({
+                'plain_links': true
+              })
+            );
 
   generate(path.join(__dirname, 'fixtures/footnote_simple_link.txt'), md);
 });

--- a/test/test.js
+++ b/test/test.js
@@ -23,3 +23,14 @@ describe('markdown-it-footnote-labels', function () {
 
   generate(path.join(__dirname, 'fixtures/footnote_labels.txt'), md);
 });
+
+describe('markdown-it-footnote-simple-links', function () {
+  var md = require('markdown-it')()
+              .use(require('../')( 
+                {
+                    'plain_links': true
+                })
+              );
+
+  generate(path.join(__dirname, 'fixtures/footnote_simple_link.txt'), md);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -12,3 +12,14 @@ describe('markdown-it-footnote', function () {
 
   generate(path.join(__dirname, 'fixtures/footnote.txt'), md);
 });
+
+describe('markdown-it-footnote-labels', function () {
+  var md = require('markdown-it')()
+              .use(require('../')( 
+                {
+                    'labels_in_link': true
+                })
+              );
+
+  generate(path.join(__dirname, 'fixtures/footnote_labels.txt'), md);
+});


### PR DESCRIPTION
1. `plain_links`
    Allow the user to change the default output of the reference links form `[1]` to `1`.

2. `labels_in_link`
    Include the label in the footnote's href so `[^something-here]` generates `<a href="#fn4:something-here" ...`

All these changes are backward compatible which means that current users should not see any change in behavior.