### PR TITLE
Proposed support for UUID anchor IDs

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 var merge = require('merge');
 
 var defaultOptions = {
+  'omit_square_brackets': false
 };
 
 module.exports = function sub_plugin(md, options) {
@@ -22,7 +23,8 @@ module.exports = function sub_plugin(md, options) {
     if (tokens[idx].meta.subId > 0) {
       id += ':' + tokens[idx].meta.subId;
     }
-  return '<sup class="footnote-ref"><a href="#fn' + n + '" id="' + id + '">[' + n + ']</a></sup>';
+    var text = options.omit_square_brackets ? n : '[' + n + ']';
+    return '<sup class="footnote-ref"><a href="#fn' + n + '" id="' + id + '">' + text + '</a></sup>';
   }
   function _footnote_block_open(tokens, idx, options) {
     return (options.xhtmlOut ? '<hr class="footnotes-sep" />\n' : '<hr class="footnotes-sep">\n') +

--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ module.exports = function sub_plugin(md, options) {
     if (!silent) {
       if (!state.env.footnotes) { state.env.footnotes = {}; }
       if (!state.env.footnotes.list) { state.env.footnotes.list = []; }
-      footnoteId = options.use_uuids ? uuid.v4() : state.env.footnotes.list.length;
+      footnoteId = options.use_uuids ? uuid.v4() : state.env.footnotes.list.length + 1;
 
       state.md.inline.parse(
         state.src.slice(labelStart, labelEnd),
@@ -291,8 +291,10 @@ module.exports = function sub_plugin(md, options) {
 
     for (i = 0, l = list.length; i < l; i++) {
       token      = new state.Token('footnote_open', '', 1);
-      token.meta = { id: i };
+      token.meta = { id: list[i].id };
       state.tokens.push(token);
+
+      var outerToken = token;
 
       if (list[i].tokens) {
         tokens = [];
@@ -311,7 +313,6 @@ module.exports = function sub_plugin(md, options) {
         tokens.push(token);
 
       } else if (list[i].label) {
-        token.meta.id = list[i].id;
         tokens = refTokens[':' + list[i].label];
       }
 
@@ -324,7 +325,6 @@ module.exports = function sub_plugin(md, options) {
 
       t = list[i].count > 0 ? list[i].count : 1;
       for (j = 0; j < t; j++) {
-        var outerToken = token;
         token      = new state.Token('footnote_anchor', '', 0);
         token.meta = { id: outerToken.meta.id, subId: j };
         state.tokens.push(token);

--- a/index.js
+++ b/index.js
@@ -229,14 +229,18 @@ module.exports = function sub_plugin(md, options) {
     if (!silent) {
       if (!state.env.footnotes.list) { state.env.footnotes.list = []; }
 
-      if (state.env.footnotes.refs[':' + label].index == null) {
+      if (state.env.footnotes.refs[':' + label].index === null) {
         footnoteIndex = state.env.footnotes.list.length;
         state.env.footnotes.refs[':' + label].index = state.env.footnotes.list.length;
       } else {
         footnoteIndex = state.env.footnotes.refs[':' + label].index;
       }
 
-      footnoteId = state.env.footnotes.refs[':' + label].id
+      if (state.env.footnotes.refs[':' + label].id === null) {
+        state.env.footnotes.refs[':' + label].id = footnoteIndex + 1;
+      }
+
+      footnoteId = state.env.footnotes.refs[':' + label].id;
 
       if (typeof state.env.footnotes.list[footnoteIndex] === 'undefined') {
         state.env.footnotes.list[footnoteIndex] = { label: label, count: 0, id: footnoteId, index: footnoteIndex };
@@ -307,7 +311,7 @@ module.exports = function sub_plugin(md, options) {
         tokens.push(token);
 
       } else if (list[i].label) {
-        token.meta.id = list[i].id
+        token.meta.id = list[i].id;
         tokens = refTokens[':' + list[i].label];
       }
 
@@ -320,7 +324,7 @@ module.exports = function sub_plugin(md, options) {
 
       t = list[i].count > 0 ? list[i].count : 1;
       for (j = 0; j < t; j++) {
-        var outerToken = token
+        var outerToken = token;
         token      = new state.Token('footnote_anchor', '', 0);
         token.meta = { id: outerToken.meta.id, subId: j };
         state.tokens.push(token);

--- a/index.js
+++ b/index.js
@@ -2,47 +2,53 @@
 //
 'use strict';
 
-////////////////////////////////////////////////////////////////////////////////
-// Renderer partials
+var merge = require('merge');
 
-function _footnote_ref(tokens, idx) {
-  var n = Number(tokens[idx].meta.id + 1).toString();
-  var id = 'fnref' + n;
-  if (tokens[idx].meta.subId > 0) {
-    id += ':' + tokens[idx].meta.subId;
-  }
-  return '<sup class="footnote-ref"><a href="#fn' + n + '" id="' + id + '">[' + n + ']</a></sup>';
-}
-function _footnote_block_open(tokens, idx, options) {
-  return (options.xhtmlOut ? '<hr class="footnotes-sep" />\n' : '<hr class="footnotes-sep">\n') +
-         '<section class="footnotes">\n' +
-         '<ol class="footnotes-list">\n';
-}
-function _footnote_block_close() {
-  return '</ol>\n</section>\n';
-}
-function _footnote_open(tokens, idx) {
-  var id = Number(tokens[idx].meta.id + 1).toString();
-  return '<li id="fn' + id + '"  class="footnote-item">';
-}
-function _footnote_close() {
-  return '</li>\n';
-}
-function _footnote_anchor(tokens, idx) {
-  var n = Number(tokens[idx].meta.id + 1).toString();
-  var id = 'fnref' + n;
-  if (tokens[idx].meta.subId > 0) {
-    id += ':' + tokens[idx].meta.subId;
-  }
-  return ' <a href="#' + id + '" class="footnote-backref">\u21a9</a>'; /* ↩ */
-}
+var defaultOptions = {
+};
 
-////////////////////////////////////////////////////////////////////////////////
+module.exports = function sub_plugin(md, options) {
+  options = merge(defaultOptions, options);
 
-
-module.exports = function sub_plugin(md) {
   var parseLinkLabel = md.helpers.parseLinkLabel,
       isSpace = md.utils.isSpace;
+
+  ////////////////////////////////////////////////////////////////////////////////
+  // Renderer partials
+
+  function _footnote_ref(tokens, idx) {
+    var n = Number(tokens[idx].meta.id + 1).toString();
+    var id = 'fnref' + n;
+    if (tokens[idx].meta.subId > 0) {
+      id += ':' + tokens[idx].meta.subId;
+    }
+  return '<sup class="footnote-ref"><a href="#fn' + n + '" id="' + id + '">[' + n + ']</a></sup>';
+  }
+  function _footnote_block_open(tokens, idx, options) {
+    return (options.xhtmlOut ? '<hr class="footnotes-sep" />\n' : '<hr class="footnotes-sep">\n') +
+           '<section class="footnotes">\n' +
+           '<ol class="footnotes-list">\n';
+  }
+  function _footnote_block_close() {
+    return '</ol>\n</section>\n';
+  }
+  function _footnote_open(tokens, idx) {
+    var id = Number(tokens[idx].meta.id + 1).toString();
+    return '<li id="fn' + id + '"  class="footnote-item">';
+  }
+  function _footnote_close() {
+    return '</li>\n';
+  }
+  function _footnote_anchor(tokens, idx) {
+    var n = Number(tokens[idx].meta.id + 1).toString();
+    var id = 'fnref' + n;
+    if (tokens[idx].meta.subId > 0) {
+      id += ':' + tokens[idx].meta.subId;
+    }
+    return ' <a href="#' + id + '" class="footnote-backref">\u21a9</a>'; /* ↩ */
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////
 
   md.renderer.rules.footnote_ref          = _footnote_ref;
   md.renderer.rules.footnote_block_open   = _footnote_block_open;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "scripts": {
     "test": "make test"
   },
+  "dependencies": {
+    "merge": "^1.2.0",
+  },
   "devDependencies": {
     "browserify": "*",
     "coveralls": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "merge": "^1.2.0",
+    "node-uuid": "^1.4.7"    
   },
   "devDependencies": {
     "browserify": "*",


### PR DESCRIPTION
This introduces a potential solution for displaying multiple articles/posts/whatever rendered by markdown-it to be displayed on the same page. For example, the index page of a blog may have the full text (including footnotes) of three or more articles, each separately rendered by separate calls into markdown-it. In this case, there will be a collision between footnote 1 of article 1 and footnote 1 of article 2.

This proposed solution introduces an option for using randomly generated anchor IDs, while still displaying regular numerals to the user, as before.

(This PR also includes an option for omitting square brackets in displayed footnote references, which is a requirement for my site...I'm happy to break it into a different PR or remove it entirely if you prefer.)

I know you've been against adding options in the past (I know someone proposed them to remove square brackets in #2) but I'd argue this is an important enough addition to add an option for it.

Happy to receive feedback on this. Thanks!