### PR TITLE
Avoid footnote ID collisions across multiple documents

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 function prefixedId(id, env) {
   var prefix = '';
   if (typeof env.documentId === 'string') {
-    prefix = env.documentId + '-';
+    prefix = '-' + env.documentId + '-';
   }
   return prefix + id;
 }

--- a/index.js
+++ b/index.js
@@ -2,16 +2,24 @@
 //
 'use strict';
 
+function prefixedId(id, env) {
+  var prefix = '';
+  if (typeof env.documentId === 'string') {
+    prefix = env.documentId + '-';
+  }
+  return prefix + id;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Renderer partials
 
-function _footnote_ref(tokens, idx) {
+function _footnote_ref(tokens, idx, options, env) {
   var n = Number(tokens[idx].meta.id + 1).toString();
-  var id = 'fnref' + n;
+  var id = 'fnref' + prefixedId(n, env);
   if (tokens[idx].meta.subId > 0) {
     id += ':' + tokens[idx].meta.subId;
   }
-  return '<sup class="footnote-ref"><a href="#fn' + n + '" id="' + id + '">[' + n + ']</a></sup>';
+  return '<sup class="footnote-ref"><a href="#fn' + prefixedId(n, env) + '" id="' + id + '">[' + n + ']</a></sup>';
 }
 function _footnote_block_open(tokens, idx, options) {
   return (options.xhtmlOut ? '<hr class="footnotes-sep" />\n' : '<hr class="footnotes-sep">\n') +
@@ -21,16 +29,16 @@ function _footnote_block_open(tokens, idx, options) {
 function _footnote_block_close() {
   return '</ol>\n</section>\n';
 }
-function _footnote_open(tokens, idx) {
-  var id = Number(tokens[idx].meta.id + 1).toString();
+function _footnote_open(tokens, idx, options, env) {
+  var id = prefixedId(Number(tokens[idx].meta.id + 1).toString(), env);
   return '<li id="fn' + id + '"  class="footnote-item">';
 }
 function _footnote_close() {
   return '</li>\n';
 }
-function _footnote_anchor(tokens, idx) {
+function _footnote_anchor(tokens, idx, options, env) {
   var n = Number(tokens[idx].meta.id + 1).toString();
-  var id = 'fnref' + n;
+  var id = 'fnref' + prefixedId(n, env);
   if (tokens[idx].meta.subId > 0) {
     id += ':' + tokens[idx].meta.subId;
   }
@@ -38,7 +46,6 @@ function _footnote_anchor(tokens, idx) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
 
 module.exports = function sub_plugin(md) {
   var parseLinkLabel = md.helpers.parseLinkLabel,

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 
 function prefixedId(id, env) {
   var prefix = '';
-  if (typeof env.documentId === 'string') {
+  if (typeof env.documentId === 'string' && env.documentId.length > 0) {
     prefix = '-' + env.documentId + '-';
   }
   return prefix + id;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "markdown-it-testgen": "~0.1.0",
     "mocha": "*",
     "request": "*",
-    "uglify-js": "*",
-    "chai": "~ 1.10.0"
+    "uglify-js": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "istanbul": "*",
     "lodash": "*",
     "markdown-it": "markdown-it/markdown-it",
-    "markdown-it-testgen": "~0.1.0",
+    "markdown-it-testgen": "git://github.com/sadlerjw/markdown-it-testgen.git#env-testing",
     "mocha": "*",
     "request": "*",
     "uglify-js": "*"

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "istanbul": "*",
     "lodash": "*",
     "markdown-it": "markdown-it/markdown-it",
-    "markdown-it-testgen": "git://github.com/sadlerjw/markdown-it-testgen.git#env-testing",
+    "markdown-it-testgen": "~0.1.0",
     "mocha": "*",
     "request": "*",
-    "uglify-js": "*"
+    "uglify-js": "*",
+    "chai": "~ 1.10.0"
   }
 }

--- a/test/fixtures/footnote-prefixed.txt
+++ b/test/fixtures/footnote-prefixed.txt
@@ -19,22 +19,22 @@ belong to the previous footnote.
 This paragraph won't be part of the note, because it
 isn't indented.
 .
-<p>Here is a footnote reference,<sup class="footnote-ref"><a href="#fntest-doc-id-1" id="fnreftest-doc-id-1">[1]</a></sup> and another.<sup class="footnote-ref"><a href="#fntest-doc-id-2" id="fnreftest-doc-id-2">[2]</a></sup></p>
+<p>Here is a footnote reference,<sup class="footnote-ref"><a href="#fn-test-doc-id-1" id="fnref-test-doc-id-1">[1]</a></sup> and another.<sup class="footnote-ref"><a href="#fn-test-doc-id-2" id="fnref-test-doc-id-2">[2]</a></sup></p>
 <p>This paragraph won't be part of the note, because it
 isn't indented.</p>
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fntest-doc-id-1"  class="footnote-item"><p>Here is the footnote. <a href="#fnreftest-doc-id-1" class="footnote-backref">↩</a></p>
+<li id="fn-test-doc-id-1"  class="footnote-item"><p>Here is the footnote. <a href="#fnref-test-doc-id-1" class="footnote-backref">↩</a></p>
 </li>
-<li id="fntest-doc-id-2"  class="footnote-item"><p>Here's one with multiple blocks.</p>
+<li id="fn-test-doc-id-2"  class="footnote-item"><p>Here's one with multiple blocks.</p>
 <p>Subsequent paragraphs are indented to show that they
 belong to the previous footnote.</p>
 <pre><code>{ some.code }
 </code></pre>
 <p>The whole paragraph can be indented, or just the first
 line.  In this way, multi-paragraph footnotes work like
-multi-paragraph list items. <a href="#fnreftest-doc-id-2" class="footnote-backref">↩</a></p>
+multi-paragraph list items. <a href="#fnref-test-doc-id-2" class="footnote-backref">↩</a></p>
 </li>
 </ol>
 </section>

--- a/test/fixtures/footnote-prefixed.txt
+++ b/test/fixtures/footnote-prefixed.txt
@@ -1,0 +1,41 @@
+
+Pandoc example:
+.
+Here is a footnote reference,[^1] and another.[^longnote]
+
+[^1]: Here is the footnote.
+
+[^longnote]: Here's one with multiple blocks.
+
+    Subsequent paragraphs are indented to show that they
+belong to the previous footnote.
+
+        { some.code }
+
+    The whole paragraph can be indented, or just the first
+    line.  In this way, multi-paragraph footnotes work like
+    multi-paragraph list items.
+
+This paragraph won't be part of the note, because it
+isn't indented.
+.
+<p>Here is a footnote reference,<sup class="footnote-ref"><a href="#fntest-doc-id-1" id="fnreftest-doc-id-1">[1]</a></sup> and another.<sup class="footnote-ref"><a href="#fntest-doc-id-2" id="fnreftest-doc-id-2">[2]</a></sup></p>
+<p>This paragraph won't be part of the note, because it
+isn't indented.</p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fntest-doc-id-1"  class="footnote-item"><p>Here is the footnote. <a href="#fnreftest-doc-id-1" class="footnote-backref">↩</a></p>
+</li>
+<li id="fntest-doc-id-2"  class="footnote-item"><p>Here's one with multiple blocks.</p>
+<p>Subsequent paragraphs are indented to show that they
+belong to the previous footnote.</p>
+<pre><code>{ some.code }
+</code></pre>
+<p>The whole paragraph can be indented, or just the first
+line.  In this way, multi-paragraph footnotes work like
+multi-paragraph list items. <a href="#fnreftest-doc-id-2" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.

--- a/test/test.js
+++ b/test/test.js
@@ -3,17 +3,34 @@
 
 var path     = require('path');
 var generate = require('markdown-it-testgen');
+var assert   = require('chai').assert;
+var _        = require('lodash');
 
 /*eslint-env mocha*/
 
-describe('markdown-it-footnote', function () {
-  it('Should work with default settings', function() {
-    var md = require('markdown-it')().use(require('../'));
-	generate(path.join(__dirname, 'fixtures/footnote.txt'), md);
-  });
+// Most of the rest of this is inlined from generate(), but modified
+// so we can pass in an `env` object
+function generateWithEnvironment(fixturePath, md, env) {
+  generate.load(fixturePath, {}, function (data) {
+    data.meta = data.meta || {};
 
-  it('Should work with prefixed IDs', function () {
-    var md = require('markdown-it')().use(require('../'));
-    generate(path.join(__dirname, 'fixtures/footnote-prefixed.txt'), {}, { documentId: 'test-doc-id' }, md);
+    var desc = data.meta.desc || path.relative(fixturePath, data.file);
+
+    (data.meta.skip ? describe.skip : describe)(desc, function () {
+      data.fixtures.forEach(function (fixture) {
+        it('line ' + (fixture.first.range[0] - 1), function () {
+          assert.strictEqual(md.render(fixture.first.text, _.clone(env)), fixture.second.text);
+        });
+      });
+    });
   });
- });
+}
+
+describe('markdown-it-footnote', function () {
+  // Check that defaults work correctly
+  var md = require('markdown-it')().use(require('../'));
+  generate(path.join(__dirname, 'fixtures/footnote.txt'), md);
+
+  // Now check that using `env.documentId` works to prefix IDs
+  generateWithEnvironment(path.join(__dirname, 'fixtures/footnote-prefixed.txt'), md, { documentId: 'test-doc-id' });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -7,8 +7,13 @@ var generate = require('markdown-it-testgen');
 /*eslint-env mocha*/
 
 describe('markdown-it-footnote', function () {
-  var md = require('markdown-it')()
-              .use(require('../'));
+  it('Should work with default settings', function() {
+    var md = require('markdown-it')().use(require('../'));
+	generate(path.join(__dirname, 'fixtures/footnote.txt'), md);
+  });
 
-  generate(path.join(__dirname, 'fixtures/footnote.txt'), md);
-});
+  it('Should work with prefixed IDs', function () {
+    var md = require('markdown-it')().use(require('../'));
+    generate(path.join(__dirname, 'fixtures/footnote-prefixed.txt'), {}, { documentId: 'test-doc-id' }, md);
+  });
+ });

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@
 
 var path     = require('path');
 var generate = require('markdown-it-testgen');
-var assert   = require('chai').assert;
+var assert   = require('assert');
 var _        = require('lodash');
 
 /*eslint-env mocha*/


### PR DESCRIPTION
Based on discussion in #7 - if `env.documentId` is supplied and is a non-empty string, footnote IDs are now in the form `fn-some-document-id-1` / `fnref-some-document-id-1`. (See #7 for details)

To test, I needed a version of `generate()` from [markdown-it-testgen](https://github.com/markdown-it/markdown-it-testgen) that supported passing an `env` variable through to `render`. After discussion in https://github.com/markdown-it/markdown-it-testgen/pull/1, I inlined most of `generate` with the necessary modifications. (This also required me to add chai as a new dev dependency.)