### PR TITLE
Add configurable footnoteId and footnoteCaption renderers

### DIFF
--- a/test/fixtures/custom-footnotes.txt
+++ b/test/fixtures/custom-footnotes.txt
@@ -1,0 +1,27 @@
+
+Custom ids/captions example:
+.
+Here is a footnote reference,[^1] and another,[^longnote] and an inline footnote ^[it works!].
+
+[^1]: Here is the footnote.
+
+[^longnote]: Here's one with multiple blocks.
+
+    Subsequent paragraphs are indented to show that they
+belong to the previous footnote.
+.
+<p>Here is a footnote reference,<sup class="footnote-ref"><a href="#fn-1" id="fnref-1">{1}</a></sup> and another,<sup class="footnote-ref"><a href="#fn-longnote" id="fnref-longnote">{longnote}</a></sup> and an inline footnote <sup class="footnote-ref"><a href="#fn3" id="fnref3">{3}</a></sup>.</p>
+<hr class="footnotes-sep">
+<section class="footnotes">
+<ol class="footnotes-list">
+<li id="fn-1"  class="footnote-item"><p>Here is the footnote. <a href="#fnref-1" class="footnote-backref">↩</a></p>
+</li>
+<li id="fn-longnote"  class="footnote-item"><p>Here's one with multiple blocks.</p>
+<p>Subsequent paragraphs are indented to show that they
+belong to the previous footnote. <a href="#fnref-longnote" class="footnote-backref">↩</a></p>
+</li>
+<li id="fn3"  class="footnote-item"><p>it works! <a href="#fnref3" class="footnote-backref">↩</a></p>
+</li>
+</ol>
+</section>
+.

--- a/test/test.js
+++ b/test/test.js
@@ -12,3 +12,20 @@ describe('markdown-it-footnote', function () {
 
   generate(path.join(__dirname, 'fixtures/footnote.txt'), md);
 });
+
+describe('custom footnote ids and labels', function () {
+  var md = require('markdown-it')({
+    footnoteId: function(n, token) {
+      if (token.meta.label) {
+        return '-' + token.meta.label;
+      }
+      return n;
+    },
+
+    footnoteCaption: function(n, token) {
+      return '{' + (token.meta.label || n) + '}';
+    }
+  }).use(require('../'));
+
+  generate(path.join(__dirname, 'fixtures/custom-footnotes.txt'), md);
+});


### PR DESCRIPTION
Similar to #8, I am wrestling with footnote ids for multiple markdown bodies in the same page. In addition, I want the hash URLs for footnotes to be stable if new footnotes are added. This proposal would allow you to customize the id and caption output by writing your own renderer.

For instance, to generate stable footnote ids using labels (when available):

```js
require('markdown-it')({
  footnoteId: function(n, token) {
    if (token.meta.label) {
      return '-' + token.meta.label;
    }
    return n;
  },
}).use(require('markdown-it-footnote'))
```

Similarly, one could implement a `footnoteId` function which includes a per-document id.

One downside to this approach is that a custom renderer could introduce security issues since it's output directly into the HTML. Do you have any other ideas for mitigating this, or do you think it's ok as-is? One idea would be to escape the custom renderer output as a fail-safe.