### PR TITLE
remove subID footnote caption display

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,9 @@ function render_footnote_anchor_name(tokens, idx, options, env/*, slf*/) {
 function render_footnote_caption(tokens, idx/*, options, env, slf*/) {
   var n = Number(tokens[idx].meta.id + 1).toString();
 
-  if (tokens[idx].meta.subId > 0) {
-    n += ':' + tokens[idx].meta.subId;
-  }
+  // if (tokens[idx].meta.subId > 0) {
+  //   n += ':' + tokens[idx].meta.subId;
+  // }
 
   return '[' + n + ']';
 }

--- a/index.js
+++ b/index.js
@@ -18,11 +18,6 @@ function render_footnote_anchor_name(tokens, idx, options, env/*, slf*/) {
 
 function render_footnote_caption(tokens, idx/*, options, env, slf*/) {
   var n = Number(tokens[idx].meta.id + 1).toString();
-
-  // if (tokens[idx].meta.subId > 0) {
-  //   n += ':' + tokens[idx].meta.subId;
-  // }
-
   return '[' + n + ']';
 }
 


### PR DESCRIPTION
Many, many thanks for markdown-it, markdown-it-footnote and friends.

This request is a suggestion to remove the subId in render_footnote_caption(). Design-wise, it doesn't really add any necessary information or additional functionality to the rendered document. 

So that instead of the following **example document** (see red arrow): 
![screen shot 2017-06-06 at 4 10 13 pm](https://user-images.githubusercontent.com/4317308/26899986-b1fa2a1a-4b85-11e7-9420-dcbfc7c229f3.png)


---

we would have **this document**:  
![screen shot 2017-06-06 at 4 07 42 pm](https://user-images.githubusercontent.com/4317308/26900003-bc91fd90-4b85-11e7-8860-266357c9c94d.png)

Note the back-reference functionality here will still be intact– the relevant ids (e.g. id="fnref1" id="fnref1:1") in the link tags are still present. Thus the relevant lines in the text body will still be linked to when clicking on the footnote-backref arrows.
