### PR TITLE
Add tabindex to make li focusable

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function render_footnote_open(tokens, idx, options, env, slf) {
     id += ':' + tokens[idx].meta.subId;
   }
 
-  return '<li id="fn' + id + '" class="footnote-item">';
+  return '<li tabindex="-1" id="fn' + id + '" class="footnote-item">';
 }
 
 function render_footnote_close() {

--- a/test/fixtures/footnote-prefixed.txt
+++ b/test/fixtures/footnote-prefixed.txt
@@ -23,9 +23,9 @@ isn't indented.</p>
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn-test-doc-id-1" class="footnote-item"><p>Here is the footnote. <a href="#fnref-test-doc-id-1" class="footnote-backref">↩</a></p>
+<li tabindex="-1" id="fn-test-doc-id-1" class="footnote-item"><p>Here is the footnote. <a href="#fnref-test-doc-id-1" class="footnote-backref">↩</a></p>
 </li>
-<li id="fn-test-doc-id-2" class="footnote-item"><p>Here's one with multiple blocks.</p>
+<li tabindex="-1" id="fn-test-doc-id-2" class="footnote-item"><p>Here's one with multiple blocks.</p>
 <p>Subsequent paragraphs are indented to show that they
 belong to the previous footnote.</p>
 <pre><code>{ some.code }

--- a/test/fixtures/footnote.txt
+++ b/test/fixtures/footnote.txt
@@ -25,9 +25,9 @@ isn't indented.</p>
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn1" class="footnote-item"><p>Here is the footnote. <a href="#fnref1" class="footnote-backref">↩</a></p>
+<li tabindex="-1" id="fn1" class="footnote-item"><p>Here is the footnote. <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
-<li id="fn2" class="footnote-item"><p>Here's one with multiple blocks.</p>
+<li tabindex="-1" id="fn2" class="footnote-item"><p>Here's one with multiple blocks.</p>
 <p>Subsequent paragraphs are indented to show that they
 belong to the previous footnote.</p>
 <pre><code>{ some.code }
@@ -55,11 +55,11 @@ They could terminate each other:
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn1" class="footnote-item"><p>foo <a href="#fnref1" class="footnote-backref">↩</a></p>
+<li tabindex="-1" id="fn1" class="footnote-item"><p>foo <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
-<li id="fn2" class="footnote-item"><p>bar <a href="#fnref2" class="footnote-backref">↩</a></p>
+<li tabindex="-1" id="fn2" class="footnote-item"><p>bar <a href="#fnref2" class="footnote-backref">↩</a></p>
 </li>
-<li id="fn3" class="footnote-item"><p>baz <a href="#fnref3" class="footnote-backref">↩</a></p>
+<li tabindex="-1" id="fn3" class="footnote-item"><p>baz <a href="#fnref3" class="footnote-backref">↩</a></p>
 </li>
 </ol>
 </section>
@@ -78,7 +78,7 @@ baz
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn1" class="footnote-item"><p>bar
+<li tabindex="-1" id="fn1" class="footnote-item"><p>bar
 baz <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
 </ol>
@@ -111,7 +111,7 @@ note.]
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn1" class="footnote-item"><p>Inlines notes are easier to write, since
+<li tabindex="-1" id="fn1" class="footnote-item"><p>Inlines notes are easier to write, since
 you don't have to pick an identifier and move down to type the
 note. <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
@@ -129,7 +129,7 @@ foo^[ *bar* ]
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn1" class="footnote-item"><p> <em>bar</em>  <a href="#fnref1" class="footnote-backref">↩</a></p>
+<li tabindex="-1" id="fn1" class="footnote-item"><p> <em>bar</em>  <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
 </ol>
 </section>
@@ -146,7 +146,7 @@ Duplicate footnotes:
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn1" class="footnote-item"><p>foo <a href="#fnref1" class="footnote-backref">↩︎</a> <a href="#fnref1:1" class="footnote-backref">↩︎</a></p>
+<li tabindex="-1" id="fn1" class="footnote-item"><p>foo <a href="#fnref1" class="footnote-backref">↩︎</a> <a href="#fnref1:1" class="footnote-backref">↩︎</a></p>
 </li>
 </ol>
 </section>
@@ -169,9 +169,9 @@ Indents:
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn1" class="footnote-item"><h2>foo</h2>
+<li tabindex="-1" id="fn1" class="footnote-item"><h2>foo</h2>
  <a href="#fnref1" class="footnote-backref">↩</a></li>
-<li id="fn2" class="footnote-item"><p>foo <a href="#fnref2" class="footnote-backref">↩</a></p>
+<li tabindex="-1" id="fn2" class="footnote-item"><p>foo <a href="#fnref2" class="footnote-backref">↩</a></p>
 </li>
 </ol>
 </section>
@@ -191,9 +191,9 @@ Indents for the first line:
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn1" class="footnote-item"><p>foo <a href="#fnref1" class="footnote-backref">↩</a></p>
+<li tabindex="-1" id="fn1" class="footnote-item"><p>foo <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
-<li id="fn2" class="footnote-item"><pre><code>foo
+<li tabindex="-1" id="fn2" class="footnote-item"><pre><code>foo
 </code></pre>
  <a href="#fnref2" class="footnote-backref">↩</a></li>
 </ol>
@@ -210,7 +210,7 @@ Indents for the first line (tabs):
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn1" class="footnote-item"><p>foo <a href="#fnref1" class="footnote-backref">↩</a></p>
+<li tabindex="-1" id="fn1" class="footnote-item"><p>foo <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
 </ol>
 </section>
@@ -227,7 +227,7 @@ Security 1
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn1" class="footnote-item"><p>blah <a href="#fnref1" class="footnote-backref">↩</a></p>
+<li tabindex="-1" id="fn1" class="footnote-item"><p>blah <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
 </ol>
 </section>
@@ -244,7 +244,7 @@ Security 2
 <hr class="footnotes-sep">
 <section class="footnotes">
 <ol class="footnotes-list">
-<li id="fn1" class="footnote-item"><p>blah <a href="#fnref1" class="footnote-backref">↩</a></p>
+<li tabindex="-1" id="fn1" class="footnote-item"><p>blah <a href="#fnref1" class="footnote-backref">↩</a></p>
 </li>
 </ol>
 </section>


### PR DESCRIPTION
Also fixes https://github.com/markdown-it/markdown-it-footnote/issues/24

Now we can style it with `.footnote-item:focus {}`