### PR TITLE
fix: docId resolve error in render_footnote_anchor_name

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function render_footnote_anchor_name(tokens, idx, options, env/*, slf*/) {
   var n = Number(tokens[idx].meta.id + 1).toString();
   var prefix = '';
 
-  if (typeof env.docId === 'string') {
+  if (env && typeof env.docId === 'string') {
     prefix = '-' + env.docId + '-';
   }
 


### PR DESCRIPTION
This small change allows rendering footnote if the env is missing.

For example, for footnotes in headers like this: https://github.com/oleeskild/obsidian-digital-garden/issues/204

 