### PR TITLE
Fix index.mjs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ package system, module will add itself globally as `window.markdownitFootnote`.
 
 If you want to customize the output, you'll need to replace the template
 functions. To see which templates exist and their default implementations,
-look in [`index.js`](index.js). The API of these template functions is out of
+look in [`index.js`](index.mjs). The API of these template functions is out of
 scope for this plugin's documentation; you can read more about it [in the
 markdown-it
 documentation](https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer).


### PR DESCRIPTION
While reading the docs, following link to `index.js` lead to a 404 since file was renamed `index.mjs`.